### PR TITLE
Ubuntu的passwd命令不支持--stdin选项，使用chpasswd替代，在CentOS上已经验证有效

### DIFF
--- a/juser/user_api.py
+++ b/juser/user_api.py
@@ -151,8 +151,8 @@ def server_add_user(username, password, ssh_key_pwd='', ssh_key_login_need=True)
     add a system user in jumpserver
     在jumpserver服务器上添加一个用户
     """
-    bash("useradd -s %s/connect.py '%s'; echo '%s'; echo '%s' | passwd --stdin '%s'" % 
-         (BASE_DIR, username, password, password, username))
+    bash("useradd -s %s/connect.py '%s'; echo '%s'; echo '%s:%s' | chpasswd " %
+         (BASE_DIR, username, password, username, password))
     if ssh_key_login_need:
         gen_ssh_key(username, ssh_key_pwd)
 


### PR DESCRIPTION
RT.